### PR TITLE
Add TypeScript definitions file

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "browser": "dist/index.js",
   "main": "dist/index.js",
   "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "start": "npx http-server -o /demo/",
     "clean": "shx rm -rf ./dist",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,3 +24,22 @@ export interface DirectoryOpenOptions {
 export function directoryOpen(options?: DirectoryOpenOptions): Promise<File[]>;
 
 export function imageToBlob(img: HTMLImageElement): Promise<Blob>;
+
+// The following typings implement the relevant parts of the Native File System API.
+// This can be removed once the specification reaches the Candidate phase and is
+// implemented as part of microsoft/TSJS-lib-generator.
+
+export interface FileSystemHandlePermissionDescriptor {
+  writable: boolean,
+}
+
+export interface FileSystemHandle {
+  readonly isFile: boolean,
+  readonly isDirectory: boolean,
+  readonly name: string,
+
+  isSameEntry: (other: FileSystemHandle) => Promise<boolean>,
+
+  queryPermission: (descriptor?: FileSystemHandlePermissionDescriptor) => Promise<PermissionState>,
+  requestPermission: (descriptor?: FileSystemHandlePermissionDescriptor) => Promise<PermissionState>,
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,26 @@
+export interface FileOpenOptions {
+  mimeTypes: string[],
+  extensions: string[],
+  multiple: boolean,
+  description: string,
+}
+
+export function fileOpen(options?: FileOpenOptions): Promise<File | File[]>;
+
+export interface FileSaveOptions {
+  mimeTypes: string[],
+  extensions: string[],
+  multiple: boolean,
+  description: string,
+}
+
+export function fileSave(blob: Blob, options?: FileSaveOptions, handle?: FileSystemHandle | null): Promise<void>;
+
+export interface DirectoryOpenOptions {
+  recursive: boolean,
+  multiple: boolean,
+}
+
+export function directoryOpen(options?: DirectoryOpenOptions): Promise<File[]>;
+
+export function imageToBlob(img: HTMLImageElement): Promise<Blob>;


### PR DESCRIPTION
The definition is based on the JSDoc comments, and they assume #3 is correct (i.e. `DirectoryOpenOptions.recursive` should be a `boolean`).

TypeScript currently does not support the Native File System API as [the specification/implementation progress does not currently meet the requirements](https://github.com/microsoft/TSJS-lib-generator#additions), so I've included temporary definitions for `FileSystemHandle` and `FileSystemHandlePermissionDescriptor`. This _should_ scale gracefully once support is actually added provided the interface in the specification does not change significantly. (An alternative solution would be to simply not include these two interfaces and have `fileSave` take a generic `object` as its `handle` argument.)