### PR TITLE
Reliably dispose Blob URLs

### DIFF
--- a/demo/script.mjs
+++ b/demo/script.mjs
@@ -34,7 +34,7 @@ import {
     const img = document.createElement('img');
     img.src = URL.createObjectURL(blob);
     document.body.append(img);
-    setTimeout(() => URL.revokeObjectURL(img.src), 0);
+    img.onload = img.onerror = () => URL.revokeObjectURL(img.src);
   };
 
   const listDirectory = (blobs) => {
@@ -99,6 +99,7 @@ import {
     try {
       const blobs = await directoryOpen();
       listDirectory(blobs);
+      console.timeEnd('dir');
     } catch (err) {
       if (err.name !== 'AbortError') {
         console.error(err);

--- a/demo/script.mjs
+++ b/demo/script.mjs
@@ -99,7 +99,6 @@ import {
     try {
       const blobs = await directoryOpen();
       listDirectory(blobs);
-      console.timeEnd('dir');
     } catch (err) {
       if (err.name !== 'AbortError') {
         console.error(err);


### PR DESCRIPTION

setTimeout is prone to race conditions, whereas disposing URLs when images are definitely loaded (or errored out) guarantees that URL is, indeed, no longer required.