### PR TITLE
Parallelise operations

### DIFF
--- a/src/nativefs/file-open-nativefs.mjs
+++ b/src/nativefs/file-open-nativefs.mjs
@@ -15,6 +15,12 @@
  */
 // @license © 2020 Google LLC. Licensed under the Apache License, Version 2.0.
 
+const getFileWithHandle = async (handle) => {
+  const file = await handle.getFile();
+  file.handle = handle;
+  return file;
+};
+
 /**
  * Opens a file from disk using the Native File System API.
  * @param {Object} [options] - Optional options object.
@@ -25,30 +31,18 @@
  * @return {File | File[]} Opened file(s).
  */
 export default async (options = {}) => {
-  try {
-    const handleOrHandles = await window.chooseFileSystemEntries({
-      accepts: [
-        {
-          description: options.description || '',
-          mimeTypes: options.mimeTypes || ['*/*'],
-          extensions: options.extensions || [''],
-        },
-      ],
-      multiple: options.multiple || false,
-    });
-    if (options.multiple) {
-      const files = [];
-      for (const handle of handleOrHandles) {
-        const file = await handle.getFile();
-        file.handle = handle;
-        files.push(file);
-      }
-      return files;
-    }
-    const file = await handleOrHandles.getFile();
-    file.handle = handleOrHandles;
-    return file;
-  } catch (err) {
-    throw err;
+  const handleOrHandles = await window.chooseFileSystemEntries({
+    accepts: [
+      {
+        description: options.description || '',
+        mimeTypes: options.mimeTypes || ['*/*'],
+        extensions: options.extensions || [''],
+      },
+    ],
+    multiple: options.multiple || false,
+  });
+  if (options.multiple) {
+    return Promise.all(handleOrHandles.map(getFileWithHandle));
   }
+  return getFileWithHandle(handleOrHandles);
 };

--- a/src/nativefs/file-save-nativefs.mjs
+++ b/src/nativefs/file-save-nativefs.mjs
@@ -25,23 +25,19 @@
  * @param {FileSystemHandle} [handle] - Optional file handle to save in place.
  */
 export default async (blob, options = {}, handle = null) => {
-  try {
-    options.fileName = options.fileName || 'Untitled';
-    handle = handle || await window.chooseFileSystemEntries({
-      type: 'save-file',
-      accepts: [
-        {
-          description: options.description || '',
-          mimeTypes: [blob.type],
-          extensions: options.extensions || [''],
-        },
-      ],
-    });
-    const writable = await handle.createWritable();
-    await writable.write(blob);
-    await writable.close();
-    return handle;
-  } catch (err) {
-    throw err;
-  }
+  options.fileName = options.fileName || 'Untitled';
+  handle = handle || await window.chooseFileSystemEntries({
+    type: 'save-file',
+    accepts: [
+      {
+        description: options.description || '',
+        mimeTypes: [blob.type],
+        extensions: options.extensions || [''],
+      },
+    ],
+  });
+  const writable = await handle.createWritable();
+  await writable.write(blob);
+  await writable.close();
+  return handle;
 };


### PR DESCRIPTION

Before this, reading multiple files or directories has been done serially, even though Native File System provides a Promise-based API.

This PR leverages the API to full extent by scheduling all reads in parallel, and then waiting for all results.

On an example of a folder with 100 files, this makes the "open directory" demo go down from 90ms to 60ms (1.5x speedup) on my machine, and will be even better on larger lists.