### PR TITLE
Provide consistent webkitRelativePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,6 @@ const blobs = await fileOpen(options);
 
 ### Opening directories:
 
-Note that there are some differences between the Native File System API
-and the fallback approach
-[`<input type="file" webkitdirectory multiple>`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitdirectory).
-Namely, the Native File System API currently doesn't provide useful
-relative path info as
-[`webkitRelativePath`](https://developer.mozilla.org/en-US/docs/Web/API/File/webkitRelativePath)
-did, so you need to keep track of paths yourself.
-
 ```js
 // Options are optional.
 const options = {
@@ -99,6 +91,8 @@ const options = {
 
 const blobs = await directoryOpen(options);
 ```
+
+The module also polyfills a [`webkitRelativePath`](https://developer.mozilla.org/en-US/docs/Web/API/File/webkitRelativePath) property on returned files in a consistent way, regardless of the underlying implementation.
 
 ### Saving files:
 

--- a/demo/script.mjs
+++ b/demo/script.mjs
@@ -38,22 +38,11 @@ import {
   const listDirectory = (blobs) => {
     let fileStructure = '';
     blobs
-      .sort((a, b) => {
-        a = a.webkitRelativePath + a.name;
-        b = b.webkitRelativePath + b.name;
-        if (a < b) {
-          return -1;
-        } else if (a > b) {
-          return 1;
-        }
-        return 0;
-      })
+      .sort((a, b) => a.webkitRelativePath.localeCompare(b))
       .forEach((blob) => {
         // The Native File System API currently reports the `webkitRelativePath`
         // as empty string `''`.
-        fileStructure += `${blob.webkitRelativePath}${
-          blob.webkitRelativePath.endsWith(blob.name) ? '' : blob.name
-        }\n`;
+        fileStructure += `${blob.webkitRelativePath}\n`;
       });
     pre.textContent += fileStructure;
 


### PR DESCRIPTION

Before this, demo of opening a directory returned different filenames depending on the implementation used.

This PR polyfills a webkitRelativePath, making underlying implementations even less distinguishable.