### PR TITLE
fix build on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "npx http-server -o /demo/",
     "clean": "shx rm -rf ./dist",
-    "build": "npm run clean && shx mkdir ./dist && shx mkdir ./dist/util && shx mkdir ./dist/legacy && shx mkdir ./dist/nativefs && shx mkdir ./dist/nativefs-legacy && npx ./build.sh",
+    "build": "npm run clean && shx mkdir ./dist && shx mkdir ./dist/util && shx mkdir ./dist/legacy && shx mkdir ./dist/nativefs && shx mkdir ./dist/nativefs-legacy && bash ./build.sh",
     "prepare": "npm run lint && npm run fix && npm run build",
     "lint": "npx eslint . --ext .js,.mjs --fix --ignore-pattern dist/",
     "fix": "npx prettier --write ."


### PR DESCRIPTION
`npx ./build.sh` can't be run on windows. Not sure what `npx` does, but I assume it just falls back to executing `./build.sh` which fails on Windows in case it's run from Command prompt (or the like), even when `bash`/`sh` is installed.

Thus I'm reverting to running `bash` explicitly. This obviously requires it to be installed, but the `build.sh` script would fail if it weren't ITFP.