### PR TITLE
add fileName to FileSaveOptions and add comments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ export function fileOpen(options?: {
 export function fileOpen(options?: {
   mimeTypes?: string[];
   extensions?: string[];
+  /** defaults to "" */
   description?: string;
   multiple?: false;
 }): Promise<File>;
@@ -16,7 +17,10 @@ export interface FileSaveOptions {
   mimeTypes: string[];
   extensions: string[];
   multiple: boolean;
-  description: string;
+  /** defaults to "Untitled" */
+  fileName?: string;
+  /** defaults to "" */
+  description?: string;
 }
 
 export function fileSave(


### PR DESCRIPTION
- add `fileName` to `FileSaveOptions`
- made `description` optional
- added a few comments

I presume deduplicating type information & docs by removing JSDoc and moving it to TS annotations. Sounds good for a future PR?